### PR TITLE
Generic Payload Parser for DSSE

### DIFF
--- a/securesystemslib/exceptions.py
+++ b/securesystemslib/exceptions.py
@@ -113,3 +113,13 @@ class StorageError(Error):
   """Indicate an error occured during interaction with an abstracted storage
      backend."""
   pass
+
+
+class PayloadParseError(Error):
+  """Indicate an error during parsing of payload."""
+  pass
+
+
+class UnsupportedPayloadType(Error):
+  """If a payload parser does not support the given payload type."""
+  pass


### PR DESCRIPTION
Fixes: #

### Description of the changes being introduced by the pull request:
payload is a byte sequence of serialized body, stored in Envelope, that
need to be parsed according to given payload_type in Envelope.

Generic Parser is added, so that a type of Parser can be created
according to the requirements of in-toto/tuf.

In form of an example JSONParser is added which parse serialized JSON
payloads and return them in form of dict. It will be used to test the
Payload parsing capabilities of Generic Parser.


### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


