### PR TITLE
Add Serialization Module

### DIFF
--- a/securesystemslib/exceptions.py
+++ b/securesystemslib/exceptions.py
@@ -119,3 +119,13 @@ class StorageError(Error):
 class SignatureVerificationError(Error):
   """Indicate an error occurred during signature verification of DSSE."""
   pass
+
+
+class SerializationError(Error):
+  """Error during serialization."""
+  pass
+
+
+class DeserializationError(Error):
+  """Error during deserialization."""
+  pass

--- a/securesystemslib/metadata.py
+++ b/securesystemslib/metadata.py
@@ -180,7 +180,8 @@ class Envelope(SerializationMixin, JSONSerializable):
         """Parse DSSE payload.
 
         Arguments:
-            class_type: A class having a from_dict method.
+            class_type: The class to be deserialized. If the default
+                deserializer is used, it must implement ``JSONSerializable``.
             deserializer: ``BaseDeserializer`` implementation to use.
                 Default is JSONDeserializer.
 

--- a/securesystemslib/metadata.py
+++ b/securesystemslib/metadata.py
@@ -6,18 +6,15 @@ from typing import Any, Dict, List, Optional
 
 from securesystemslib import exceptions, formats
 from securesystemslib.key import Key
-from securesystemslib.serialization import (
-    BaseDeserializer,
-    JSONDeserializer,
-    Serializable,
-)
+from securesystemslib.serialization import (BaseDeserializer, BaseSerializer,
+    JSONDeserializer, JSONSerializable, JSONSerializer, SerializationMixin)
 from securesystemslib.signer import GPGSignature, Signature, Signer
 from securesystemslib.util import b64dec, b64enc
 
 logger = logging.getLogger(__name__)
 
 
-class Envelope(Serializable):
+class Envelope(SerializationMixin, JSONSerializable):
     """DSSE Envelope to provide interface for signing arbitrary data.
 
     Attributes:
@@ -47,9 +44,17 @@ class Envelope(Serializable):
             and self.signatures == other.signatures
         )
 
+    @staticmethod
+    def default_deserializer() -> BaseDeserializer:
+        return JSONDeserializer()
+
+    @staticmethod
+    def default_serializer() -> BaseSerializer:
+        return JSONSerializer()
+
     @classmethod
     def from_dict(cls, data: dict) -> "Envelope":
-        """Creates a Signature object from its JSON/dict representation.
+        """Creates a DSSE Envelope from its JSON/dict representation.
 
         Arguments:
             data: A dict containing a valid payload, payloadType and signatures

--- a/securesystemslib/metadata.py
+++ b/securesystemslib/metadata.py
@@ -2,17 +2,22 @@
 """
 
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from securesystemslib import exceptions, formats
 from securesystemslib.key import Key
+from securesystemslib.serialization import (
+    BaseDeserializer,
+    JSONDeserializer,
+    Serializable,
+)
 from securesystemslib.signer import GPGSignature, Signature, Signer
 from securesystemslib.util import b64dec, b64enc
 
 logger = logging.getLogger(__name__)
 
 
-class Envelope:
+class Envelope(Serializable):
     """DSSE Envelope to provide interface for signing arbitrary data.
 
     Attributes:
@@ -161,3 +166,28 @@ class Envelope:
             )
 
         return accepted_keys
+
+    def deserialize_payload(
+        self,
+        class_type: Any,
+        deserializer: Optional[BaseDeserializer] = None,
+    ) -> Any:
+        """Parse DSSE payload.
+
+        Arguments:
+            class_type: A class having a from_dict method.
+            deserializer: ``BaseDeserializer`` implementation to use.
+                Default is JSONDeserializer.
+
+        Raises:
+            DeserializationError: The payload cannot be deserialized.
+
+        Returns:
+            The deserialized object of payload.
+        """
+
+        if deserializer is None:
+            deserializer = JSONDeserializer()
+
+        payload = deserializer.deserialize(self.payload, class_type)
+        return payload

--- a/securesystemslib/serialization.py
+++ b/securesystemslib/serialization.py
@@ -1,0 +1,24 @@
+"""Serialization module provides abstract base classes and concrete
+implementations to serialize and deserialize objects.
+"""
+
+import abc
+from typing import Any
+
+
+class BaseDeserializer(metaclass=abc.ABCMeta):
+    """Abstract base class for deserialization of objects."""
+
+    @abc.abstractmethod
+    def deserialize(self, raw_data: bytes) -> Any:
+        """Deserialize bytes to a specific object."""
+        raise NotImplementedError
+
+
+class BaseSerializer(metaclass=abc.ABCMeta):
+    """Abstract base class for serialization of objects."""
+
+    @abc.abstractmethod
+    def serialize(self, obj: Any) -> bytes:
+        """Serialize an object to bytes."""
+        raise NotImplementedError

--- a/securesystemslib/serialization.py
+++ b/securesystemslib/serialization.py
@@ -21,7 +21,8 @@ class BaseDeserializer(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def deserialize(self, raw_data: bytes, cls: Any) -> Any:
         """Deserialize bytes to a specific object."""
-        raise NotImplementedError
+
+        raise NotImplementedError  # pragma: no cover
 
 
 class JSONDeserializer(BaseDeserializer):
@@ -54,7 +55,8 @@ class BaseSerializer(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def serialize(self, obj: Any) -> bytes:
         """Serialize an object to bytes."""
-        raise NotImplementedError
+
+        raise NotImplementedError  # pragma: no cover
 
 
 class JSONSerializer(BaseSerializer):

--- a/securesystemslib/serialization.py
+++ b/securesystemslib/serialization.py
@@ -15,6 +15,8 @@ from securesystemslib.storage import FilesystemBackend, StorageBackendInterface
 from securesystemslib.util import persist_temp_file
 
 
+# TODO: Use typing.Protocol post python 3.7
+# See https://github.com/in-toto/securesystemslib/issues/10.
 class BaseDeserializer(metaclass=abc.ABCMeta):
     """Abstract base class for deserialization of objects."""
 
@@ -123,7 +125,7 @@ class SerializationMixin(metaclass=abc.ABCMeta):
         cls,
         data: bytes,
         deserializer: Optional[BaseDeserializer] = None,
-    ) -> "SerializationMixin":
+    ) -> Any:
         """Loads the Serializable from raw data.
 
         Arguments:
@@ -147,7 +149,7 @@ class SerializationMixin(metaclass=abc.ABCMeta):
         filename: str,
         deserializer: Optional[BaseDeserializer] = None,
         storage_backend: Optional[StorageBackendInterface] = None,
-    ) -> "SerializationMixin":
+    ) -> Any:
         """Loads object from file storage.
 
         Arguments:
@@ -197,7 +199,7 @@ class SerializationMixin(metaclass=abc.ABCMeta):
         filename: str,
         serializer: Optional[BaseSerializer] = None,
         storage_backend: Optional[StorageBackendInterface] = None,
-    ) -> None:
+    ):
         """Writes object to file storage.
 
         Note that if a file is first deserialized and then serialized with

--- a/securesystemslib/serialization.py
+++ b/securesystemslib/serialization.py
@@ -3,16 +3,46 @@ implementations to serialize and deserialize objects.
 """
 
 import abc
+import json
 from typing import Any
+
+from securesystemslib.exceptions import (
+    DeserializationError,
+    SerializationError,
+)
 
 
 class BaseDeserializer(metaclass=abc.ABCMeta):
     """Abstract base class for deserialization of objects."""
 
     @abc.abstractmethod
-    def deserialize(self, raw_data: bytes) -> Any:
+    def deserialize(self, raw_data: bytes, cls: Any) -> Any:
         """Deserialize bytes to a specific object."""
         raise NotImplementedError
+
+
+class JSONDeserializer(BaseDeserializer):
+    """Provides raw to JSON deserialize method."""
+
+    def deserialize(self, raw_data: bytes, cls: Any) -> Any:
+        """Deserialize utf-8 encoded JSON bytes into an instance of cls.
+
+        Arguments:
+            raw_data: A utf-8 encoded bytes string.
+            cls: A class type having a from_dict method.
+
+        Returns:
+            Object of the provided class type.
+        """
+
+        try:
+            json_dict = json.loads(raw_data.decode("utf-8"))
+            obj = cls.from_dict(json_dict)
+
+        except Exception as e:
+            raise DeserializationError("Failed to deserialize bytes") from e
+
+        return obj
 
 
 class BaseSerializer(metaclass=abc.ABCMeta):
@@ -22,3 +52,42 @@ class BaseSerializer(metaclass=abc.ABCMeta):
     def serialize(self, obj: Any) -> bytes:
         """Serialize an object to bytes."""
         raise NotImplementedError
+
+
+class JSONSerializer(BaseSerializer):
+    """Provide an object to bytes serialize method.
+
+    Attributes:
+        compact: A boolean indicating if the JSON bytes generated in
+            'serialize' should be compact by excluding whitespace.
+    """
+
+    def __init__(self, compact: bool = False):
+        self.indent = 1
+        self.separators = (",", ": ")
+        if compact:
+            self.indent = None
+            self.separators = (",", ":")
+
+    def serialize(self, obj: Any) -> bytes:
+        """Serialize an object into utf-8 encoded JSON bytes.
+
+        Arguments:
+            obj: An object with to_dict method.
+
+        Returns:
+            UTF-8 encoded JSON bytes of the object.
+        """
+
+        try:
+            json_bytes = json.dumps(
+                obj.to_dict(),
+                indent=self.indent,
+                separators=self.separators,
+                sort_keys=True,
+            ).encode("utf-8")
+
+        except Exception as e:
+            raise SerializationError("Failed to serialize JSON") from e
+
+        return json_bytes

--- a/securesystemslib/serialization.py
+++ b/securesystemslib/serialization.py
@@ -28,12 +28,12 @@ class BaseDeserializer(metaclass=abc.ABCMeta):
 class JSONDeserializer(BaseDeserializer):
     """Provides raw to JSON deserialize method."""
 
-    def deserialize(self, raw_data: bytes, cls: Any) -> Any:
+    def deserialize(self, raw_data: bytes, cls: "JSONSerializable") -> Any:
         """Deserialize utf-8 encoded JSON bytes into an instance of cls.
 
         Arguments:
             raw_data: A utf-8 encoded bytes string.
-            cls: A class type having a from_dict method.
+            cls: A "JSONSerializable" subclass.
 
         Returns:
             Object of the provided class type.
@@ -74,11 +74,11 @@ class JSONSerializer(BaseSerializer):
             self.indent = None
             self.separators = (",", ":")
 
-    def serialize(self, obj: Any) -> bytes:
+    def serialize(self, obj: "JSONSerializable") -> bytes:
         """Serialize an object into utf-8 encoded JSON bytes.
 
         Arguments:
-            obj: An object with to_dict method.
+            obj: An instance of "JSONSerializable" subclass.
 
         Returns:
             UTF-8 encoded JSON bytes of the object.
@@ -98,20 +98,35 @@ class JSONSerializer(BaseSerializer):
         return json_bytes
 
 
-class Serializable(metaclass=abc.ABCMeta):
-    """Objects with Base class Serializable are to be serialized and
+class SerializationMixin(metaclass=abc.ABCMeta):
+    """Instance of class with SerializationMixin are to be serialized and
     deserialized using `to_bytes`, `from_bytes`, `to_file` and `from_file`
     methods.
     """
+
+    @staticmethod
+    @abc.abstractmethod
+    def default_deserializer() -> BaseDeserializer:
+        """Default Deserializer to be used for deserialization"""
+
+        raise NotImplementedError  # pragma: no cover
+
+    @staticmethod
+    @abc.abstractmethod
+    def default_serializer() -> BaseSerializer:
+        """Default Serializer to be used for serialization."""
+
+        raise NotImplementedError  # pragma: no cover
 
     @classmethod
     def from_bytes(
         cls,
         data: bytes,
         deserializer: Optional[BaseDeserializer] = None,
-    ) -> "Serializable":
+    ) -> "SerializationMixin":
         """Loads the Serializable from raw data.
-        Args:
+
+        Arguments:
             data: bytes content.
             deserializer: ``BaseDeserializer`` implementation to use.
                 Default is JSONDeserializer.
@@ -122,7 +137,7 @@ class Serializable(metaclass=abc.ABCMeta):
         """
 
         if deserializer is None:
-            deserializer = JSONDeserializer()
+            deserializer = cls.default_deserializer()
 
         return deserializer.deserialize(data, cls)
 
@@ -132,7 +147,7 @@ class Serializable(metaclass=abc.ABCMeta):
         filename: str,
         deserializer: Optional[BaseDeserializer] = None,
         storage_backend: Optional[StorageBackendInterface] = None,
-    ) -> "Serializable":
+    ) -> "SerializationMixin":
         """Loads object from file storage.
 
         Arguments:
@@ -173,7 +188,7 @@ class Serializable(metaclass=abc.ABCMeta):
         """
 
         if serializer is None:
-            serializer = JSONSerializer()
+            serializer = self.default_serializer()
 
         return serializer.serialize(self)
 
@@ -208,3 +223,26 @@ class Serializable(metaclass=abc.ABCMeta):
         with tempfile.TemporaryFile() as temp_file:
             temp_file.write(bytes_data)
             persist_temp_file(temp_file, filename, storage_backend)
+
+
+class JSONSerializable(metaclass=abc.ABCMeta):
+    """Abstract base class that provide method to convert an instance of class
+    to dict and back to an object from its JSON/dict representation.
+
+    It provides `from_dict` and `to_dict` method, therefore, JSONSerializer and
+    JSONDeserializer requires a subclass of this class for serialization and
+    deserialization.
+    """
+
+    @classmethod
+    @abc.abstractmethod
+    def from_dict(cls, data: dict) -> Any:
+        """Creates an object from its JSON/dict representation."""
+
+        raise NotImplementedError  # pragma: no cover
+
+    @abc.abstractmethod
+    def to_dict(self) -> dict:
+        """Returns the JSON-serializable dictionary representation of self."""
+
+        raise NotImplementedError  # pragma: no cover

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+
+"""Test cases for "serialization.py". """
+
+import json
+import os
+import tempfile
+import shutil
+import unittest
+
+from securesystemslib.exceptions import (
+    DeserializationError,
+    SerializationError
+)
+from securesystemslib.metadata import Envelope
+from securesystemslib.serialization import JSONDeserializer, JSONSerializer
+from securesystemslib.storage import FilesystemBackend
+
+
+class TestJSONSerialization(unittest.TestCase):
+    """Serialization Test Case."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.test_obj = Envelope(
+            payload=b"hello world",
+            payload_type="http://example.com/HelloWorld",
+            signatures=[],
+        )
+        cls.test_bytes = b'{"payload":"aGVsbG8gd29ybGQ=","payloadType":"http://example.com/HelloWorld","signatures":[]}'
+
+    def test_serializer(self):
+        """Test JSONSerializer with DSSE Envelope."""
+
+        serializer = JSONSerializer()
+
+        # Assert SerializationError on serializing a invalid object.
+        with self.assertRaises(SerializationError):
+            serializer.serialize("not a valid obj")
+
+        # Serialize compact and non compact envelope object into bytes.
+        json_bytes = serializer.serialize(self.test_obj)
+
+        serializer = JSONSerializer(compact=True)
+        compact_json_bytes = serializer.serialize(self.test_obj)
+
+        # Assert inequality between compact and non compact json bytes.
+        self.assertNotEqual(json_bytes, compact_json_bytes)
+
+        # Assert equality with the test bytes.
+        self.assertEqual(compact_json_bytes, self.test_bytes)
+
+        # Assert equality between compact and non compact json dict.
+        self.assertEqual(
+            json.loads(json_bytes),
+            json.loads(compact_json_bytes)
+        )
+
+    def test_deserializer(self):
+        """Test JSONDeserializer with DSSE Envelope."""
+
+        deserializer = JSONDeserializer()
+
+        # Assert DeserializationError on invalid json and class.
+        with self.assertRaises(DeserializationError):
+            deserializer.deserialize(b"not a valid json", Envelope)
+
+        with self.assertRaises(DeserializationError):
+            deserializer.deserialize(self.test_bytes, "not a valid type")
+
+        # Assert Equality between deserialized envelope and test object.
+        envelope_obj = deserializer.deserialize(self.test_bytes, Envelope)
+        self.assertEqual(envelope_obj, self.test_obj)
+
+    def test_serialization(self):
+        """Test JSONDeserializer and JSONSerializer."""
+
+        serializer = JSONSerializer()
+        json_bytes = serializer.serialize(self.test_obj)
+
+        deserializer = JSONDeserializer()
+        envelope_obj = deserializer.deserialize(json_bytes, Envelope)
+
+        # Assert Equality between original object and deserialized object.
+        self.assertEqual(envelope_obj, self.test_obj)
+
+
+class TestSerializable(unittest.TestCase):
+    """Serializable Type Test Case."""
+
+    def setUp(self):
+        self.storage_backend = FilesystemBackend()
+        self.temp_dir = tempfile.mkdtemp(dir=os.getcwd())
+        self.filepath = os.path.join(self.temp_dir, 'testfile')
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.test_obj = Envelope(
+            payload=b"hello world",
+            payload_type="http://example.com/HelloWorld",
+            signatures=[],
+        )
+
+    def test_to_and_from_file(self):
+        """Test to_file and from_file method of Serializable."""
+
+        # Save test_obj to a file.
+        self.test_obj.to_file(self.filepath)
+
+        # Load object from the saved file.
+        envelope_obj = Envelope.from_file(self.filepath)
+
+        # Test for equality.
+        self.assertEqual(envelope_obj, self.test_obj)
+
+    def test_to_and_from_file_with_storage_backend(self):
+        """Test to_file and from_file method of Serializable with storage
+        backend."""
+
+        # Save test_obj to a file.
+        self.test_obj.to_file(
+            self.filepath,
+            storage_backend=self.storage_backend
+        )
+
+        # Load object from the saved file.
+        envelope_obj = Envelope.from_file(
+            self.filepath,
+            storage_backend=self.storage_backend
+        )
+
+        # Test for equality.
+        self.assertEqual(envelope_obj, self.test_obj)
+
+    def test_to_and_from_bytes(self):
+        """Test to_bytes and from_bytes method of Serializable."""
+
+        # Serializer object into bytes.
+        json_bytes = self.test_obj.to_bytes()
+
+        # Deserialize object from bytes.
+        envelope_obj = Envelope.from_bytes(json_bytes)
+
+        # Test for equality.
+        self.assertEqual(envelope_obj, self.test_obj)
+
+    def test_to_and_from_bytes_with_serializer(self):
+        """Test to_bytes and from_bytes method of Serializable with JSON
+        serializer and deserializer."""
+
+        # Serializer object into bytes.
+        serializer = JSONSerializer(compact=True)
+        json_bytes = self.test_obj.to_bytes(serializer)
+
+        # Deserialize object from bytes.
+        deserializer = JSONDeserializer()
+        envelope_obj = Envelope.from_bytes(json_bytes, deserializer)
+
+        # Test for equality.
+        self.assertEqual(envelope_obj, self.test_obj)
+
+
+
+# Run the unit tests.
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description of the changes being introduced by the pull request:
Metadata classes and other similar classes requires a method to
serialize and deserialize their objects into json, bytes, and
other forms. Hence, to provide a common interface to serialize
and deserialize is a better approach.

BaseSerializer and BaseDeserializer are introduced having
method serialize and deserialize respectively. These methods will
serialize class instance to raw bytes and vice versa.

SerializationError and DeserializationError will be raised on error
occurrences.


### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


