### PR TITLE
Add match_payload method to Envelope

### DIFF
--- a/securesystemslib/metadata.py
+++ b/securesystemslib/metadata.py
@@ -197,3 +197,28 @@ class Envelope(SerializationMixin, JSONSerializable):
 
         payload = deserializer.deserialize(self.payload, class_type)
         return payload
+
+    def match_payload(
+        self,
+        class_type: Any,
+        deserializer: Optional[BaseDeserializer] = None,
+    ) -> bool:
+        """Checks for the payload if deserializes into the provided class type.
+
+        Arguments:
+            class_type: The class to be deserialized. If the default
+                deserializer is used, it must implement ``JSONSerializable``.
+            deserializer: ``BaseDeserializer`` implementation to use.
+                Default is JSONDeserializer.
+
+        Returns:
+            Boolean. Indicating the provided class type is matched with
+            payload.
+        """
+
+        try:
+            self.deserialize_payload(class_type, deserializer)
+        except exceptions.DeserializationError:
+            return False
+        else:
+            return True


### PR DESCRIPTION
### Description of the changes being introduced by the pull request:

match_payload method checks for the payoad if deserializes into
the provided class type. This method is essential in order to
add DSSE compatibility in in_toto.

This method will provide interface similar to current in_toto's
Metablock property `_type`. Which is used at various places in
in_toto project to identify type of the payload.

### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


