### PR TITLE
Serialization and Metadata API changes

### DIFF
--- a/securesystemslib/metadata.py
+++ b/securesystemslib/metadata.py
@@ -111,7 +111,7 @@ class Envelope(SerializationMixin, JSONSerializable):
             self.payload,
         )
 
-    def sign(self, signer: Signer) -> Signature:
+    def create_sig(self, signer: Signer) -> Signature:
         """Sign the payload and create the signature.
 
         Arguments:
@@ -126,7 +126,7 @@ class Envelope(SerializationMixin, JSONSerializable):
 
         return signature
 
-    def verify(self, keys: List[Key], threshold: int) -> Dict[str, Key]:
+    def verify_sigs(self, keys: List[Key], threshold: int) -> Dict[str, Key]:
         """Verify the payload with the provided Keys.
 
         Arguments:

--- a/securesystemslib/metadata.py
+++ b/securesystemslib/metadata.py
@@ -53,6 +53,16 @@ class Envelope(SerializationMixin, JSONSerializable):
         return JSONSerializer()
 
     @classmethod
+    def from_bytes(
+        cls,
+        data: bytes,
+        deserializer: Optional[BaseDeserializer] = None
+    ) -> "Envelope":
+
+        json = super().from_bytes(data, deserializer)
+        return cls.from_dict(json)
+
+    @classmethod
     def from_dict(cls, data: dict) -> "Envelope":
         """Creates a DSSE Envelope from its JSON/dict representation.
 
@@ -172,18 +182,14 @@ class Envelope(SerializationMixin, JSONSerializable):
 
         return accepted_keys
 
-    def deserialize_payload(
+    def get_payload(
         self,
-        class_type: Any,
-        deserializer: Optional[BaseDeserializer] = None,
+        deserializer: BaseDeserializer,
     ) -> Any:
         """Parse DSSE payload.
 
         Arguments:
-            class_type: The class to be deserialized. If the default
-                deserializer is used, it must implement ``JSONSerializable``.
             deserializer: ``BaseDeserializer`` implementation to use.
-                Default is JSONDeserializer.
 
         Raises:
             DeserializationError: The payload cannot be deserialized.
@@ -192,8 +198,4 @@ class Envelope(SerializationMixin, JSONSerializable):
             The deserialized object of payload.
         """
 
-        if deserializer is None:
-            deserializer = JSONDeserializer()
-
-        payload = deserializer.deserialize(self.payload, class_type)
-        return payload
+        return deserializer.deserialize(self.payload)

--- a/securesystemslib/serialization.py
+++ b/securesystemslib/serialization.py
@@ -21,7 +21,7 @@ class BaseDeserializer(metaclass=abc.ABCMeta):
     """Abstract base class for deserialization of objects."""
 
     @abc.abstractmethod
-    def deserialize(self, raw_data: bytes, cls: Any) -> Any:
+    def deserialize(self, raw_data: bytes) -> Any:
         """Deserialize bytes to a specific object."""
 
         raise NotImplementedError  # pragma: no cover
@@ -30,25 +30,21 @@ class BaseDeserializer(metaclass=abc.ABCMeta):
 class JSONDeserializer(BaseDeserializer):
     """Provides raw to JSON deserialize method."""
 
-    def deserialize(self, raw_data: bytes, cls: "JSONSerializable") -> Any:
-        """Deserialize utf-8 encoded JSON bytes into an instance of cls.
+    def deserialize(self, raw_data: bytes) -> Any:
+        """Deserialize utf-8 encoded JSON bytes into a dict.
 
         Arguments:
             raw_data: A utf-8 encoded bytes string.
-            cls: A "JSONSerializable" subclass.
 
         Returns:
             Object of the provided class type.
         """
 
         try:
-            json_dict = json.loads(raw_data.decode("utf-8"))
-            obj = cls.from_dict(json_dict)
+            return json.loads(raw_data.decode("utf-8"))
 
         except Exception as e:
             raise DeserializationError("Failed to deserialize bytes") from e
-
-        return obj
 
 
 class BaseSerializer(metaclass=abc.ABCMeta):
@@ -141,7 +137,7 @@ class SerializationMixin(metaclass=abc.ABCMeta):
         if deserializer is None:
             deserializer = cls.default_deserializer()
 
-        return deserializer.deserialize(data, cls)
+        return deserializer.deserialize(data)
 
     @classmethod
     def from_file(
@@ -229,19 +225,9 @@ class SerializationMixin(metaclass=abc.ABCMeta):
 
 class JSONSerializable(metaclass=abc.ABCMeta):
     """Abstract base class that provide method to convert an instance of class
-    to dict and back to an object from its JSON/dict representation.
-
-    It provides `from_dict` and `to_dict` method, therefore, JSONSerializer and
-    JSONDeserializer requires a subclass of this class for serialization and
-    deserialization.
+    to dict. It provides `to_dict` method, therefore, JSONSerializer requires
+    a subclass of this class for serialization.
     """
-
-    @classmethod
-    @abc.abstractmethod
-    def from_dict(cls, data: dict) -> Any:
-        """Creates an object from its JSON/dict representation."""
-
-        raise NotImplementedError  # pragma: no cover
 
     @abc.abstractmethod
     def to_dict(self) -> dict:

--- a/securesystemslib/serialization.py
+++ b/securesystemslib/serialization.py
@@ -5,7 +5,7 @@ implementations to serialize and deserialize objects.
 import abc
 import json
 import tempfile
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from securesystemslib.exceptions import (
     DeserializationError,
@@ -22,7 +22,7 @@ class BaseDeserializer(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def deserialize(self, raw_data: bytes) -> Any:
-        """Deserialize bytes to a specific object."""
+        """Deserialize bytes."""
 
         raise NotImplementedError  # pragma: no cover
 
@@ -30,14 +30,17 @@ class BaseDeserializer(metaclass=abc.ABCMeta):
 class JSONDeserializer(BaseDeserializer):
     """Provides raw to JSON deserialize method."""
 
-    def deserialize(self, raw_data: bytes) -> Any:
+    def deserialize(self, raw_data: bytes) -> Dict:
         """Deserialize utf-8 encoded JSON bytes into a dict.
 
         Arguments:
             raw_data: A utf-8 encoded bytes string.
 
+        Raises:
+            DeserializationError: If fails to decode raw_data into json.
+
         Returns:
-            Object of the provided class type.
+            dict.
         """
 
         try:
@@ -224,9 +227,8 @@ class SerializationMixin(metaclass=abc.ABCMeta):
 
 
 class JSONSerializable(metaclass=abc.ABCMeta):
-    """Abstract base class that provide method to convert an instance of class
-    to dict. It provides `to_dict` method, therefore, JSONSerializer requires
-    a subclass of this class for serialization.
+    """Objects serialized with ``JSONSerializer`` must inherit from this class
+    and implement its ``to_dict`` method..
     """
 
     @abc.abstractmethod

--- a/securesystemslib/serialization.py
+++ b/securesystemslib/serialization.py
@@ -228,7 +228,7 @@ class SerializationMixin(metaclass=abc.ABCMeta):
 
 class JSONSerializable(metaclass=abc.ABCMeta):
     """Objects serialized with ``JSONSerializer`` must inherit from this class
-    and implement its ``to_dict`` method..
+    and implement its ``to_dict`` method.
     """
 
     @abc.abstractmethod

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -667,18 +667,18 @@ class TestGPGRSA(unittest.TestCase):
 
     # Create a GPGSigner and create a DSSE signature.
     gpg_signer = GPGSigner(homedir=self.gnupg_home)
-    gpg_signature = envelope.sign(gpg_signer)
+    gpg_signature = envelope.create_sig(gpg_signer)
     self.assertIsInstance(gpg_signature, GPGSignature)
     
     # Create a GPGKey and verify the DSSE signature.
     gpgkey = GPGKey.from_keyring(keyid=self.default_keyid, homedir=self.gnupg_home)
     key_list: List[Key] = [gpgkey]
-    envelope.verify(key_list, 1)
+    envelope.verify_sigs(key_list, 1)
 
     # Duplicate GPGKey.
     new_key_list = key_list + key_list
     with self.assertRaises(SignatureVerificationError):
-      envelope.verify(new_key_list, 2)
+      envelope.verify_sigs(new_key_list, 2)
 
 
 @unittest.skipIf(not HAVE_GPG, "gpg not found")
@@ -776,13 +776,13 @@ class TestGPGDSA(unittest.TestCase):
 
     # Create a GPGSigner and create a DSSE signature.
     gpg_signer = GPGSigner(homedir=self.gnupg_home)
-    gpg_signature = envelope.sign(gpg_signer)
+    gpg_signature = envelope.create_sig(gpg_signer)
     self.assertIsInstance(gpg_signature, GPGSignature)
     
     # Create a GPGKey and verify the DSSE signature.
     gpgkey = GPGKey.from_keyring(keyid=self.default_keyid, homedir=self.gnupg_home)
     key_list: List[Key] = [gpgkey]
-    envelope.verify(key_list, 1)
+    envelope.verify_sigs(key_list, 1)
 
 
 
@@ -871,13 +871,13 @@ class TestGPGEdDSA(unittest.TestCase):
 
     # Create a GPGSigner and create a DSSE signature.
     gpg_signer = GPGSigner(homedir=self.gnupg_home)
-    gpg_signature = envelope.sign(gpg_signer)
+    gpg_signature = envelope.create_sig(gpg_signer)
     self.assertIsInstance(gpg_signature, GPGSignature)
     
     # Create a GPGKey and verify the DSSE signature.
     gpgkey = GPGKey.from_keyring(keyid=self.default_keyid, homedir=self.gnupg_home)
     key_list: List[Key] = [gpgkey]
-    envelope.verify(key_list, 1)
+    envelope.verify_sigs(key_list, 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -117,12 +117,12 @@ class TestEnvelope(unittest.TestCase):
             key_dict["scheme"] = "invalid_scheme"
             signer = SSlibSigner(key_dict)
             with self.assertRaises((FormatError, UnsupportedAlgorithmError)):
-                envelope_obj.sign(signer)
+                envelope_obj.create_sig(signer)
 
             # Sign the payload.
             key_dict["scheme"] = valid_scheme
             signer = SSlibSigner(key_dict)
-            envelope_obj.sign(signer)
+            envelope_obj.create_sig(signer)
 
             # Create a List of "Key" from key_dict.
             key_list.append(SSlibKey.from_securesystemslib_key(key_dict))
@@ -135,14 +135,14 @@ class TestEnvelope(unittest.TestCase):
         # Test for invalid threshold value for keys_list.
         # threshold is 0.
         with self.assertRaises(ValueError):
-            envelope_obj.verify(key_list, 0)
+            envelope_obj.verify_sigs(key_list, 0)
 
         # threshold is greater than no of keys.
         with self.assertRaises(ValueError):
-            envelope_obj.verify(key_list, 4)
+            envelope_obj.verify_sigs(key_list, 4)
 
         # Test with valid keylist and threshold.
-        verified_keys = envelope_obj.verify(key_list, len(key_list))
+        verified_keys = envelope_obj.verify_sigs(key_list, len(key_list))
         self.assertEqual(len(verified_keys), len(key_list))
 
         # Test for unknown keys and threshold of 1.
@@ -156,15 +156,15 @@ class TestEnvelope(unittest.TestCase):
             new_key_list.append(SSlibKey.from_securesystemslib_key(key_dict))
 
         with self.assertRaises(SignatureVerificationError):
-            envelope_obj.verify(new_key_list, 1)
+            envelope_obj.verify_sigs(new_key_list, 1)
 
         all_keys = key_list + new_key_list
-        envelope_obj.verify(all_keys, 3)
+        envelope_obj.verify_sigs(all_keys, 3)
 
         # Test with duplicate keys.
         duplicate_keys = key_list + key_list
         with self.assertRaises(SignatureVerificationError):
-            envelope_obj.verify(duplicate_keys, 4)  # 3 unique keys, threshold 4.
+            envelope_obj.verify_sigs(duplicate_keys, 4)  # 3 unique keys, threshold 4.
 
 # Run the unit tests.
 if __name__ == "__main__":

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -12,7 +12,7 @@ from securesystemslib.exceptions import (
     DeserializationError,
     SerializationError
 )
-from securesystemslib.metadata import Envelope
+from securesystemslib.metadata import Envelope, EnvelopeJSONDeserializer
 from securesystemslib.serialization import JSONDeserializer, JSONSerializer
 from securesystemslib.storage import FilesystemBackend
 
@@ -156,7 +156,7 @@ class TestSerializationMixin(unittest.TestCase):
         json_bytes = self.test_obj.to_bytes(serializer)
 
         # Deserialize object from bytes.
-        deserializer = JSONDeserializer()
+        deserializer = EnvelopeJSONDeserializer()
         envelope_obj = Envelope.from_bytes(json_bytes, deserializer)
 
         # Test for equality.

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -63,13 +63,12 @@ class TestJSONSerialization(unittest.TestCase):
 
         # Assert DeserializationError on invalid json and class.
         with self.assertRaises(DeserializationError):
-            deserializer.deserialize(b"not a valid json", Envelope)
-
-        with self.assertRaises(DeserializationError):
-            deserializer.deserialize(self.test_bytes, "not a valid type")
+            deserializer.deserialize(b"not a valid json")
 
         # Assert Equality between deserialized envelope and test object.
-        envelope_obj = deserializer.deserialize(self.test_bytes, Envelope)
+        envelope_dict = deserializer.deserialize(self.test_bytes)
+        envelope_obj = Envelope.from_dict(envelope_dict)
+
         self.assertEqual(envelope_obj, self.test_obj)
 
     def test_serialization(self):
@@ -79,14 +78,15 @@ class TestJSONSerialization(unittest.TestCase):
         json_bytes = serializer.serialize(self.test_obj)
 
         deserializer = JSONDeserializer()
-        envelope_obj = deserializer.deserialize(json_bytes, Envelope)
+        envelope_dict = deserializer.deserialize(json_bytes)
+        envelope_obj = Envelope.from_dict(envelope_dict)
 
         # Assert Equality between original object and deserialized object.
         self.assertEqual(envelope_obj, self.test_obj)
 
 
-class TestSerializable(unittest.TestCase):
-    """Serializable Type Test Case."""
+class TestSerializationMixin(unittest.TestCase):
+    """SerializationMixin Test Case."""
 
     def setUp(self):
         self.storage_backend = FilesystemBackend()


### PR DESCRIPTION
### Description of the changes being introduced by the pull request:

BaseDeserializer requires a class type to deserialize the raw_data
into a class. This creates a problem with Paylaod Deserialization,
where we have to deserialize the same payload multiple time.

BaseDeserializer, JSONDeserializer returns json and that get
converted into the class object after that. Payload Deserialization
will be app specific and will be implemented at project level.

sign is renamed to create_sig and verify is renamed to verify_sigs,
so it does not clashes with other methods of current signature
wrappers.

### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


