### PR TITLE
Documentation fixes in serialization.py

### DIFF
--- a/securesystemslib/metadata.py
+++ b/securesystemslib/metadata.py
@@ -70,11 +70,11 @@ class Envelope(SerializationMixin, JSONSerializable):
         )
 
     @staticmethod
-    def default_deserializer() -> BaseDeserializer:
+    def _default_deserializer() -> BaseDeserializer:
         return EnvelopeJSONDeserializer()
 
     @staticmethod
-    def default_serializer() -> BaseSerializer:
+    def _default_serializer() -> BaseSerializer:
         return JSONSerializer()
 
     @classmethod

--- a/securesystemslib/serialization.py
+++ b/securesystemslib/serialization.py
@@ -79,7 +79,7 @@ class JSONSerializer(BaseSerializer):
         """Serialize an object into utf-8 encoded JSON bytes.
 
         Arguments:
-            obj: An instance of "JSONSerializable" subclass.
+            obj: An instance of ``JSONSerializable`` subclass.
 
         Returns:
             UTF-8 encoded JSON bytes of the object.
@@ -107,14 +107,14 @@ class SerializationMixin(metaclass=abc.ABCMeta):
 
     @staticmethod
     @abc.abstractmethod
-    def default_deserializer() -> BaseDeserializer:
+    def _default_deserializer() -> BaseDeserializer:
         """Default Deserializer to be used for deserialization"""
 
         raise NotImplementedError  # pragma: no cover
 
     @staticmethod
     @abc.abstractmethod
-    def default_serializer() -> BaseSerializer:
+    def _default_serializer() -> BaseSerializer:
         """Default Serializer to be used for serialization."""
 
         raise NotImplementedError  # pragma: no cover
@@ -125,20 +125,19 @@ class SerializationMixin(metaclass=abc.ABCMeta):
         data: bytes,
         deserializer: Optional[BaseDeserializer] = None,
     ) -> Any:
-        """Loads the Serializable from raw data.
+        """Loads the object from raw data.
 
         Arguments:
             data: bytes content.
             deserializer: ``BaseDeserializer`` implementation to use.
-                Default is JSONDeserializer.
         Raises:
             DeserializationError: The file cannot be deserialized.
         Returns:
-            The Serializable object.
+            Deserialized object.
         """
 
         if deserializer is None:
-            deserializer = cls.default_deserializer()
+            deserializer = cls._default_deserializer()
 
         return deserializer.deserialize(data)
 
@@ -162,7 +161,7 @@ class SerializationMixin(metaclass=abc.ABCMeta):
             StorageError: The file cannot be read.
             DeserializationError: The file cannot be deserialized.
         Returns:
-            The Serializable object.
+            Deserialized object.
         """
 
         if storage_backend is None:
@@ -183,13 +182,13 @@ class SerializationMixin(metaclass=abc.ABCMeta):
 
         Arguments:
             serializer: ``BaseSerializer`` instance that implements the
-                desired serialization format. Default is ``JSONSerializer``.
+                desired serialization format.
         Raises:
-            SerializationError: The Serializable object cannot be serialized.
+            SerializationError: If object cannot be serialized.
         """
 
         if serializer is None:
-            serializer = self.default_serializer()
+            serializer = self._default_serializer()
 
         return serializer.serialize(self)
 
@@ -215,7 +214,7 @@ class SerializationMixin(metaclass=abc.ABCMeta):
             storage_backend: ``StorageBackendInterface`` implementation.
                 Default  is ``FilesystemBackend`` (i.e. a local file).
         Raises:
-            SerializationError: The Serializable object cannot be serialized.
+            SerializationError: If object cannot be serialized.
             StorageError: The file cannot be written.
         """
 

--- a/securesystemslib/serialization.py
+++ b/securesystemslib/serialization.py
@@ -37,7 +37,8 @@ class JSONDeserializer(BaseDeserializer):
             raw_data: A utf-8 encoded bytes string.
 
         Raises:
-            DeserializationError: If fails to decode raw_data into json.
+            securesystemslib.exceptions.DeserializationError: If fails to
+                decode raw_data into json.
 
         Returns:
             dict.
@@ -79,7 +80,12 @@ class JSONSerializer(BaseSerializer):
         """Serialize an object into utf-8 encoded JSON bytes.
 
         Arguments:
-            obj: An instance of ``JSONSerializable`` subclass.
+            obj: An instance of
+                ``securesystemslib.serialization.JSONSerializable`` subclass.
+
+        Raises:
+            securesystemslib.exceptions.SerializationError: If fails to encode
+                into json bytes.
 
         Returns:
             UTF-8 encoded JSON bytes of the object.
@@ -100,7 +106,7 @@ class JSONSerializer(BaseSerializer):
 
 
 class SerializationMixin(metaclass=abc.ABCMeta):
-    """Instance of class with SerializationMixin are to be serialized and
+    """Instance of class with ``SerializationMixin`` are to be serialized and
     deserialized using `to_bytes`, `from_bytes`, `to_file` and `from_file`
     methods.
     """
@@ -108,7 +114,7 @@ class SerializationMixin(metaclass=abc.ABCMeta):
     @staticmethod
     @abc.abstractmethod
     def _default_deserializer() -> BaseDeserializer:
-        """Default Deserializer to be used for deserialization"""
+        """Default Deserializer to be used for deserialization."""
 
         raise NotImplementedError  # pragma: no cover
 
@@ -129,9 +135,11 @@ class SerializationMixin(metaclass=abc.ABCMeta):
 
         Arguments:
             data: bytes content.
-            deserializer: ``BaseDeserializer`` implementation to use.
+            deserializer: ``securesystemslib.serialization.BaseDeserializer``
+                implementation to use.
         Raises:
-            DeserializationError: The file cannot be deserialized.
+            securesystemslib.exceptions.DeserializationError: The file cannot
+                be deserialized.
         Returns:
             Deserialized object.
         """
@@ -152,14 +160,17 @@ class SerializationMixin(metaclass=abc.ABCMeta):
 
         Arguments:
             filename: Path to read the file from.
-            deserializer: ``BaseDeserializer`` subclass instance that
-                implements the desired wireline format deserialization.
+            deserializer: ``securesystemslib.serialization.BaseDeserializer``
+                subclass instance that implements the desired wireline
+                format deserialization.
             storage_backend: Object that implements
                 ``securesystemslib.storage.StorageBackendInterface``.
-                Default is ``FilesystemBackend`` (i.e. a local file).
+                Default is ``securesystemslib.storage.FilesystemBackend``
+                (i.e. a local file).
         Raises:
-            StorageError: The file cannot be read.
-            DeserializationError: The file cannot be deserialized.
+            securesystemslib.exceptions.StorageError: The file cannot be read.
+            securesystemslib.exceptions.DeserializationError: The file cannot
+                be deserialized.
         Returns:
             Deserialized object.
         """
@@ -181,10 +192,11 @@ class SerializationMixin(metaclass=abc.ABCMeta):
         instead of re-serializing.
 
         Arguments:
-            serializer: ``BaseSerializer`` instance that implements the
-                desired serialization format.
+            serializer: ``securesystemslib.serialization.BaseSerializer``
+                instance that implements the desired serialization format.
         Raises:
-            SerializationError: If object cannot be serialized.
+            securesystemslib.exceptions.SerializationError: If object cannot be
+                serialized.
         """
 
         if serializer is None:
@@ -209,13 +221,17 @@ class SerializationMixin(metaclass=abc.ABCMeta):
 
         Arguments:
             filename: Path to write the file to.
-            serializer: ``BaseSerializer`` instance that implements the
-                desired serialization format. Default is ``JSONSerializer``.
-            storage_backend: ``StorageBackendInterface`` implementation.
-                Default  is ``FilesystemBackend`` (i.e. a local file).
+            serializer: ``securesystemslib.serialization.BaseSerializer``
+                instance that implements the desired serialization format.
+            storage_backend: Object that implements
+                ``securesystemslib.storage.StorageBackendInterface``.
+                Default  is ``securesystemslib.storage.FilesystemBackend``
+                (i.e. a local file).
         Raises:
-            SerializationError: If object cannot be serialized.
-            StorageError: The file cannot be written.
+            securesystemslib.exceptions.SerializationError: If object cannot
+                be serialized.
+            securesystemslib.exceptions.StorageError: The file cannot be
+                written.
         """
 
         bytes_data = self.to_bytes(serializer)
@@ -226,8 +242,8 @@ class SerializationMixin(metaclass=abc.ABCMeta):
 
 
 class JSONSerializable(metaclass=abc.ABCMeta):
-    """Objects serialized with ``JSONSerializer`` must inherit from this class
-    and implement its ``to_dict`` method.
+    """Objects serialized with ``securesystemslib.serialization.JSONSerializer``
+    must inherit from this class and implement its ``to_dict`` method.
     """
 
     @abc.abstractmethod


### PR DESCRIPTION
Issue: https://github.com/in-toto/in-toto/pull/503#pullrequestreview-1099354277

### Description of the changes being introduced by the pull request:

Removing references to `Serializable` from doc string of SerializationMixin and mention of default serializer/deserializer from docs.

Changing method name of default_serializer to _default_serializer i.e. protected element of class. Also, avoid getting generated in sphinx docs.

### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


